### PR TITLE
correct the download link to the qtwebkit

### DIFF
--- a/skype/PKGBUILD
+++ b/skype/PKGBUILD
@@ -28,7 +28,7 @@ else
 fi
 
 source=(http://download.skype.com/linux/$pkgname-$pkgver.tar.bz2 PERMISSION skype-wrapper
-        ftp://ftp.archlinux.org/other/$pkgname/qtwebkit-2.2.2-i686.tar.xz)
+        https://sources.archlinux.org/other/$pkgname/qtwebkit-2.2.2-i686.tar.xz)
 md5sums=('95db8f2072b9acd6f79ed42da3d6db79'
          '26e1772379d4d4df9471b6ed660a6d97'
          '66985be1d7b953fb9f73ba6ed749812b'


### PR DESCRIPTION
It seems the urls to `ftp://ftp.archlinux.org` has moved to `https://sources.archlinux.org`

_(see: https://projects.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/qtwebkit)_